### PR TITLE
allowing 1 second variation when validating timegaps

### DIFF
--- a/qclib/utils/validate_input.py
+++ b/qclib/utils/validate_input.py
@@ -45,7 +45,7 @@ def validate_data(current_data_df: pd.DataFrame, additional_data_df: pd.DataFram
         assert has_duplicates(df) == False, "duplicated time stamps in historical data"
         assert has_time_reversed(current_data_df, additional_data_df, mode) == False, \
             "historical data are future in time or future data are historical"
-        is_valid = validate_data_for_time_gaps(df)
+        is_valid = validate_data_for_time_gaps(df, fuzzy_seconds=1)
     return is_valid
 
 
@@ -56,7 +56,7 @@ def validate_data_for_spike(current_data_df: pd.DataFrame, additional_data_df: p
             len(additional_data_df) == 1 and len(additional_data_df2) == 1:
         df = merge_data_spike(current_data_df, additional_data_df, additional_data_df2)
         assert has_duplicates(df) == False, "duplicated time stamps in historical data"
-        is_valid = validate_data_for_time_gaps(df)
+        is_valid = validate_data_for_time_gaps(df, fuzzy_seconds=1)
     return is_valid
 
 


### PR DESCRIPTION
since we don't store milliseconds, the delta between measurements are often off by one second. The function that validates time gaps should be more liberal and allow some variation in sampling frequency.

Example from a randomly selected nordbjørn signals file:

```
00 = {datetime} 2019-02-11 00:01:01
01 = {datetime} 2019-02-11 00:02:01
02 = {datetime} 2019-02-11 00:03:01
03 = {datetime} 2019-02-11 00:04:01
04 = {datetime} 2019-02-11 00:05:01
05 = {datetime} 2019-02-11 00:06:01
06 = {datetime} 2019-02-11 00:07:01
07 = {datetime} 2019-02-11 00:08:01
08 = {datetime} 2019-02-11 00:09:02
09 = {datetime} 2019-02-11 00:10:02
10 = {datetime} 2019-02-11 00:11:02
11 = {datetime} 2019-02-11 00:12:02
12 = {datetime} 2019-02-11 00:13:02
```

I implemented a param to the function "fuzzy_seconds" earlier that allows some variation in seconds, but this disappeared in what seems like a merge conflict at some stage. If this was intentional, please elaborate.